### PR TITLE
Avoid statement params being used as query for batch insert

### DIFF
--- a/src/yesql/generate.clj
+++ b/src/yesql/generate.clj
@@ -89,7 +89,7 @@
 (defn insert-handler
   [db statement-and-params call-options]
    (if (vector? (second statement-and-params))
-     (apply jdbc/db-do-prepared db statement-and-params)
+     (jdbc/db-do-prepared db true statement-and-params {:multi? true})
      (jdbc/db-do-prepared-return-keys db statement-and-params)))
 
 (defn query-handler


### PR DESCRIPTION
This fixes a problem that was causing the first parameter value to be used as the SQL query. jdbc/do-db-prepared expects to receive a vector, hence `apply` is not desirable here.